### PR TITLE
Add script to scrape pokemon names

### DIFF
--- a/scripts/get_pokedex.sh
+++ b/scripts/get_pokedex.sh
@@ -1,0 +1,8 @@
+#! /bin/sh
+
+curl -s 'https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_by_National_Pok%C3%A9dex_number' \
+        | tr -d '\n' \
+        | grep -oE 'Pokémon\)">[^<]+</a></td>' \
+        | sed -E 's/Pokémon\)">([^<]+)<\/a><\/td>/\1/' \
+        | uniq \
+        | awk -F',' -v OFS=',' '{ printf("%03i,%s\n", NR, $0) }'


### PR DESCRIPTION
Hi, cool project!

I saw your discussion about adding support using Pokemon names instead of numbers. I thought I'd help that process along, so this commit contains a script that scrapes the Pokemon names from Bulbapedia and associates them with the National Pokedex number.

It's not very robust, but it seems to work and it doesn't add any dependencies to the project. No pressure to accept if this isn't the direction you want to take though. :)