### PR TITLE
flag for half sized sprites

### DIFF
--- a/pokeget
+++ b/pokeget
@@ -373,6 +373,7 @@ getVanilla=false
 
   if [ $half == true ]; then
     pkmn="${pkmn}_half"
+  fi
 
   # Put together the final URL
 

--- a/pokeget
+++ b/pokeget
@@ -367,9 +367,16 @@ getVanilla=false
     folderName="${folderName}_named"
   fi
 
+  pkmn="${pkmnId}"
+
+  # Append "_half" if using half flag
+
+  if [ $half == true ]; then
+    pkmn="${pkmn}_half"
+
   # Put together the final URL
 
-  url="https://raw.githubusercontent.com/talwat/pokeget-sprites/main/${folderName}/${size}/${pkmnId}.txt"
+  url="https://raw.githubusercontent.com/talwat/pokeget-sprites/main/${folderName}/${size}/${pkmn}.txt"
 
   rawPkmnId=$1
   # Get final sprite using cURL

--- a/pokeget
+++ b/pokeget
@@ -78,6 +78,8 @@ help)
   echo -e "  ${BOLD}-notshiny:${RESET}      Makes the pokemon not shiny."
   echo -e "  ${BOLD}-partner:${RESET}       Makes two of the same pokemon instead of just one."
   echo -e "  ${BOLD}-variant <num>:${RESET} This flag dictates the following things: wether the pokemon is mega, alolan form, pokemon specific things such as arceus, and a few other things."
+  echo -e "  ${BOLD}-half:${RESET}          Uses block characters instead to use half the size, may not be supported on all terminal emulators."
+  echo -e "  ${BOLD}-nohalf:${RESET}        Uses regular space characters instead of block characters."
   echo -e "  ${BOLD}-random <gens>:${RESET} This flag makes a random pokemon. You can specify what generations the random pokemon will be in, or if you put '0' it will pick a random pokemon from any generation. Random generations should be separated by ',' with no spaces."
   echo -e "${BOLD}${CYAN}Credits${RESET}"
   echo "  Pokeget gets its sprites from Pokemon Reborn, which is why there may be some pokemon that look different. "
@@ -156,6 +158,7 @@ doctor)
   randomGens=()    # The default randomGens value.
   getVanilla=false # The default getfromPokeAPI value.
   partner=false    # The default partner value.
+  half=false       # The default half value.
 
   # Non-configurable variables
 
@@ -177,6 +180,9 @@ shiny=false
 
 # Determines wether the sprite will be facing backwards.
 back=false
+
+# Determines whether block characters will be used instead of spaces to use half the size.
+half=false
 
 # The variant of the sprite. Determines megas, pokemon specific things like arceus, alolan forms, etc...
 variant=\"\"
@@ -215,6 +221,12 @@ getVanilla=false
       ;;
     -variant)
       variantAsk=true
+      ;;
+    -half)
+      half=true
+      ;;
+    -nohalf)
+      half=false
       ;;
     -debug)
       debug=true


### PR DESCRIPTION
could you add half sized sprites so this pull would work for half unicode block characters? using the `▀` character, have the file name as `001_half.txt` instead of `001.txt` for example

so the sprite would use half of the space. so both halves would have separate colors, have the background color as the bottom half, and foreground color as the top half

for example, `\x1b[38;2;131;49;0;48;2;222;189;41m▀\x1b[38;2;131;49;0;48;2;255;238;82m▀` would show this
![image](https://user-images.githubusercontent.com/48314599/158051799-c6bf1a37-e63c-4d39-8a60-8dca0082ebc2.png)
